### PR TITLE
Update plugin for Redmine 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/matsukei/redmine_send_issue_reply_email.svg?branch=master)](https://travis-ci.org/matsukei/redmine_send_issue_reply_email)
 
 It is a plugin that provides the email sending feature to non Redmine users when registering notes.
+This version of the plugin is compatible with Redmine 5.1 and later.
 
 ## Usage
 

--- a/app/controllers/email_delivery_setting_of_issue_replies_controller.rb
+++ b/app/controllers/email_delivery_setting_of_issue_replies_controller.rb
@@ -14,7 +14,7 @@ class EmailDeliverySettingOfIssueRepliesController < ApplicationController
 
     ActionMailer::Base.raise_delivery_errors = true
     begin
-      @test = IssueReplyMailer.test_email(User.current, @project).deliver
+      @test = IssueReplyMailer.test_email(User.current, @project).deliver_now
       flash[:notice] = l(:notice_email_sent, ERB::Util.h(User.current.mail))
     rescue Exception => e
       flash[:error] = l(:notice_email_error, ERB::Util.h(Redmine::CodesetUtil.replace_invalid_utf8(e.message.dup)))

--- a/app/hooks/issue_controller_hook.rb
+++ b/app/hooks/issue_controller_hook.rb
@@ -4,7 +4,7 @@ module SendIssueReplyEmail
       params, issue, time_entry, journal = context.values_at(:params, :issue, :time_entry, :journal)
 
       if params['is_send_email'].to_i == 1 && journal.notes.present?
-        IssueReplyMailer.notification(issue, journal).deliver
+        IssueReplyMailer.notification(issue, journal).deliver_now
       end
     end
 

--- a/app/patches/mail_handler_patch.rb
+++ b/app/patches/mail_handler_patch.rb
@@ -10,27 +10,22 @@ module SendIssueReplyEmail
 
       private
 
-        def receive_issue_with_record_email_addresses
-          issue = receive_issue_without_record_email_addresses
+        def receive_issue(*args, &block)
+          issue = super
           EmailAddressOfIssueReply.create_by_received_mail(issue.id, email)
-
-          return issue
+          issue
         end
 
-        def receive_issue_reply_with_record_email_addresses(issue_id, from_journal = nil)
-          journal = receive_issue_reply_without_record_email_addresses(issue_id, from_journal)
+        def receive_issue_reply(issue_id, from_journal = nil, *args, &block)
+          journal = super
           EmailAddressOfIssueReply.create_by_received_mail(issue_id, email)
-
-          return journal
+          journal
         end
-
-        alias_method_chain :receive_issue, :record_email_addresses
-        alias_method_chain :receive_issue_reply, :record_email_addresses
     end
 
   end
 end
 
 SendIssueReplyEmail::MailHandlerPatch.tap do |mod|
-  MailHandler.send :include, mod unless MailHandler.include?(mod)
+  MailHandler.prepend mod
 end

--- a/app/patches/projects_helper_patch.rb
+++ b/app/patches/projects_helper_patch.rb
@@ -4,14 +4,8 @@ module SendIssueReplyEmail
   module ProjectsHelperPatch
     unloadable
 
-    extend ActiveSupport::Concern
-
-    included do
-      alias_method_chain :project_settings_tabs, :email_delivery_setting_of_issue_reply_tab
-    end
-
-    def project_settings_tabs_with_email_delivery_setting_of_issue_reply_tab
-      tabs = project_settings_tabs_without_email_delivery_setting_of_issue_reply_tab
+    def project_settings_tabs
+      tabs = super
 
       if User.current.allowed_to?(:manage_email_delivery_setting, @project) &&
           @project.module_enabled?(:send_issue_reply_email)
@@ -31,5 +25,5 @@ module SendIssueReplyEmail
 end
 
 SendIssueReplyEmail::ProjectsHelperPatch.tap do |mod|
-  ProjectsHelper.send :include, mod unless ProjectsHelper.include?(mod)
+  ProjectsHelper.prepend mod
 end

--- a/db/migrate/001_create_email_address_of_issue_replies.rb
+++ b/db/migrate/001_create_email_address_of_issue_replies.rb
@@ -1,4 +1,4 @@
-class CreateEmailAddressOfIssueReplies < ActiveRecord::Migration
+class CreateEmailAddressOfIssueReplies < ActiveRecord::Migration[6.1]
   def change
     create_table :email_address_of_issue_replies do |t|
       t.integer :issue_id, null: false

--- a/db/migrate/002_create_email_delivery_setting_of_issue_replies.rb
+++ b/db/migrate/002_create_email_delivery_setting_of_issue_replies.rb
@@ -1,4 +1,4 @@
-class CreateEmailDeliverySettingOfIssueReplies < ActiveRecord::Migration
+class CreateEmailDeliverySettingOfIssueReplies < ActiveRecord::Migration[6.1]
   def change
     create_table :email_delivery_setting_of_issue_replies do |t|
       t.integer :project_id

--- a/init.rb
+++ b/init.rb
@@ -2,8 +2,8 @@ Redmine::Plugin.register :redmine_send_issue_reply_email do
   name 'Redmine Send Issue Reply Email'
   author 'Matsukei Co.,Ltd'
   description 'It is a plugin that provides the email sending feature to non Redmine users when registering notes.'
-  version '1.0.0'
-  requires_redmine version_or_higher: '3.2.0'
+  version '1.1.0'
+  requires_redmine version_or_higher: '5.1.1'
   url 'https://github.com/matsukei/redmine_send_issue_reply_email'
   author_url 'http://www.matsukei.co.jp/'
 

--- a/test/unit/issue_reply_mailer_test.rb
+++ b/test/unit/issue_reply_mailer_test.rb
@@ -38,7 +38,7 @@ class IssueReplyMailerTest < ActiveSupport::TestCase
     email_delivery_setting.update(plain_text: true)
 
     with_settings bcc_recipients: 0 do
-      assert IssueReplyMailer.notification(issue.reload, journal).deliver
+      assert IssueReplyMailer.notification(issue.reload, journal).deliver_now
       mail = last_email
       # to: from + to or reply_to
       assert_equal [ 'dummy-from@customer.co.jp', 'dummy-to@matsukei.co.jp' ], mail.to.to_a
@@ -64,7 +64,7 @@ class IssueReplyMailerTest < ActiveSupport::TestCase
     email_delivery_setting.update(plain_text: true)
 
     with_settings bcc_recipients: 1 do
-      assert IssueReplyMailer.notification(issue.reload, journal).deliver
+      assert IssueReplyMailer.notification(issue.reload, journal).deliver_now
       mail = last_email
       # to: from + to or reply_to
       assert_equal [ 'dummy-reply-to@customer.co.jp' ], mail.to.to_a
@@ -82,7 +82,7 @@ class IssueReplyMailerTest < ActiveSupport::TestCase
     email_delivery_setting = generate_email_delivery_setting_of_same_redmine(project)
 
     email_delivery_setting.update(plain_text: false)
-    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver
+    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver_now
     assert_select_email do
       assert_select ".header" do
         assert_select "strong", text: "Header second line"
@@ -94,7 +94,7 @@ class IssueReplyMailerTest < ActiveSupport::TestCase
     end
 
     email_delivery_setting.update(plain_text: true)
-    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver
+    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver_now
     mail = last_email
     assert_equal [ 'jsmith@somenet.foo' ], mail.to.to_a
     assert_equal [], mail.cc.to_a
@@ -111,14 +111,14 @@ class IssueReplyMailerTest < ActiveSupport::TestCase
     email_delivery_setting.update(footer: '')
 
     email_delivery_setting.update(plain_text: false)
-    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver
+    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver_now
     assert_select_email do
       assert_select ".header", false
       assert_select "p", text: "Comments are written here(HTML format)."
       assert_select ".footer", false
     end
     email_delivery_setting.update(plain_text: true)
-    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver
+    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver_now
     mail = last_email
     assert_equal [ 'jsmith@somenet.foo' ], mail.to.to_a
     assert_equal [], mail.cc.to_a
@@ -134,7 +134,7 @@ class IssueReplyMailerTest < ActiveSupport::TestCase
     email_delivery_setting.update(footer: '')
 
     email_delivery_setting.update(plain_text: false)
-    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver
+    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver_now
     assert_select_email do
       assert_select ".header" do
         assert_select "strong", text: "Header second line"
@@ -143,7 +143,7 @@ class IssueReplyMailerTest < ActiveSupport::TestCase
       assert_select ".footer", false
     end
     email_delivery_setting.update(plain_text: true)
-    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver
+    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver_now
     mail = last_email
     assert_equal [ 'jsmith@somenet.foo' ], mail.to.to_a
     assert_equal [], mail.cc.to_a
@@ -159,7 +159,7 @@ class IssueReplyMailerTest < ActiveSupport::TestCase
     email_delivery_setting.update(header: '')
 
     email_delivery_setting.update(plain_text: false)
-    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver
+    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver_now
     assert_select_email do
       assert_select ".header", false
       assert_select "p", text: "Comments are written here(HTML format)."
@@ -168,7 +168,7 @@ class IssueReplyMailerTest < ActiveSupport::TestCase
       end
     end
     email_delivery_setting.update(plain_text: true)
-    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver
+    assert IssueReplyMailer.test_email(User.find(2), project.reload).deliver_now
     mail = last_email
     assert_equal [ 'jsmith@somenet.foo' ], mail.to.to_a
     assert_equal [], mail.cc.to_a


### PR DESCRIPTION
## Summary
- support Redmine 5.1+ and bump plugin version
- use `deliver_now` for mailers
- migrate to `prepend` for patches
- specify Rails 6.1 migration version
- update tests accordingly

## Testing
- `bundle exec rake -T` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `rake` *(fails: No Rakefile found)*
