### PR TITLE
Fix user argument for notification mailer

### DIFF
--- a/app/hooks/issue_controller_hook.rb
+++ b/app/hooks/issue_controller_hook.rb
@@ -4,7 +4,7 @@ module SendIssueReplyEmail
       params, issue, time_entry, journal = context.values_at(:params, :issue, :time_entry, :journal)
 
       if params['is_send_email'].to_i == 1 && journal.notes.present?
-        IssueReplyMailer.notification(issue, journal).deliver_now
+        IssueReplyMailer.notification(User.current, issue, journal).deliver_now
       end
     end
 

--- a/app/models/issue_reply_mailer.rb
+++ b/app/models/issue_reply_mailer.rb
@@ -20,7 +20,7 @@ class IssueReplyMailer < Mailer
     end
   end
 
-  def notification(issue, journal)
+  def notification(user, issue, journal)
     redmine_headers 'Project' => issue.project.identifier, 'Issue-Id' => issue.id
     message_id journal
     references issue

--- a/test/unit/issue_reply_mailer_test.rb
+++ b/test/unit/issue_reply_mailer_test.rb
@@ -38,7 +38,7 @@ class IssueReplyMailerTest < ActiveSupport::TestCase
     email_delivery_setting.update(plain_text: true)
 
     with_settings bcc_recipients: 0 do
-      assert IssueReplyMailer.notification(issue.reload, journal).deliver_now
+      assert IssueReplyMailer.notification(User.find(2), issue.reload, journal).deliver_now
       mail = last_email
       # to: from + to or reply_to
       assert_equal [ 'dummy-from@customer.co.jp', 'dummy-to@matsukei.co.jp' ], mail.to.to_a
@@ -64,7 +64,7 @@ class IssueReplyMailerTest < ActiveSupport::TestCase
     email_delivery_setting.update(plain_text: true)
 
     with_settings bcc_recipients: 1 do
-      assert IssueReplyMailer.notification(issue.reload, journal).deliver_now
+      assert IssueReplyMailer.notification(User.find(2), issue.reload, journal).deliver_now
       mail = last_email
       # to: from + to or reply_to
       assert_equal [ 'dummy-reply-to@customer.co.jp' ], mail.to.to_a


### PR DESCRIPTION
## Summary
- pass the current user when sending issue reply notifications
- update the mailer signature to accept the user
- adjust unit tests to use the new argument

## Testing
- `bundle exec rake -T` *(fails: Could not locate Gemfile)*
